### PR TITLE
only try to load the class if it's a valid module name

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
 
+  - only try to load the class if it's a valid module name
+
 0.010     2013-09-07 21:37:31Z (Karen Etheridge)
   - avoid trying to load the class if already loaded (minor optimization)
   - repository moved to the github moose organization

--- a/lib/MooseX/Types/LoadableClass.pm
+++ b/lib/MooseX/Types/LoadableClass.pm
@@ -6,19 +6,22 @@ use MooseX::Types -declare => [qw/ ClassName LoadableClass LoadableRole /];
 use MooseX::Types::Moose qw(Str RoleName), ClassName => { -as => 'MooseClassName' };
 use Moose::Util::TypeConstraints;
 use Class::Load qw(is_class_loaded load_optional_class);
+use Module::Runtime qw(is_module_name);
 use namespace::autoclean;
 
 subtype LoadableClass,
     as Str,
     where {
-        is_class_loaded($_) || load_optional_class($_)
+        is_module_name($_)
+            and is_class_loaded($_) || load_optional_class($_)
             and MooseClassName->check($_)
     };
 
 subtype LoadableRole,
     as Str,
     where {
-        is_class_loaded($_) || load_optional_class($_)
+        is_module_name($_)
+            and is_class_loaded($_) || load_optional_class($_)
             and RoleName->check($_)
     };
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -41,4 +41,14 @@ ok $@;
 ok !eval { MyClass->new(foobar_role => 'FooBarTestRoleDoesNotExist') };
 ok $@;
 
+use MooseX::Types::LoadableClass qw/LoadableClass LoadableRole/;
+
+for my $name (qw(Non::Existent::Module ::Syntactically::Invalid::Name)) {
+    for my $tc (LoadableClass, LoadableRole) {
+        ok eval { ! $tc->check($name) };
+        ok eval { ! $tc->check($name) };
+    }
+}
+
+
 done_testing;


### PR DESCRIPTION
This allows subtypes to define coercions from invalid module names, by
e.g. substituting a standard prefix for names starting with ::
