### PR TITLE
Pod::Weaver 4 now uses [-SingleEncoding]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ x_MailingList = http://lists.perl.org/list/moose.html
 [Prereqs / DevelopRequires]
 Dist::Zilla = 5.000
 
+; authordep Pod::Weaver = 4
 ; authordep Pod::Weaver::Section::Contributors
 
 [ContributorsFromGit]

--- a/weaver.ini
+++ b/weaver.ini
@@ -5,6 +5,4 @@ transformer = List
 
 [-StopWords]
 
-[-Encoding]
-
 [Contributors]


### PR DESCRIPTION
This is the same as [this commit](https://github.com/moose/MooseX-MethodAttributes/commit/b08e2c8b50c92a648ef5eb1418357ba514c5ebea) (yet another drop to my [quest](https://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7)).
