### PR TITLE
Do not declare a type that is never used

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for MooseX-Types-LoadableClass
 
 {{$NEXT}}
 
+  - do not create an extra, unused ClassName type
+
 0.014     2015-08-16 02:03:26Z
   - update some distribution tooling
 

--- a/lib/MooseX/Types/LoadableClass.pm
+++ b/lib/MooseX/Types/LoadableClass.pm
@@ -6,7 +6,7 @@ our $VERSION = '0.015';
 
 use strict;
 use warnings;
-use MooseX::Types -declare => [qw/ ClassName LoadableClass LoadableRole /];
+use MooseX::Types -declare => [qw/ LoadableClass LoadableRole /];
 use MooseX::Types::Moose qw(Str RoleName), ClassName => { -as => 'MooseClassName' };
 use Module::Runtime qw(is_module_name use_package_optimistically);
 use if MooseX::Types->VERSION >= 0.42, 'namespace::autoclean';


### PR DESCRIPTION
Previously, ClassName was declared, but the declared version of it was
never defined. Instead, the declared version was replaced by LoadableClass.

I believe this to be the underlying cause of
https://rt.cpan.org/Public/Bug/Display.html?id=119534, which exposed
this error as the previously unused sub was being called by
undefer_all.