### PR TITLE
MooseX::Types libraries aren't Moose classes, don't make_immutable

### DIFF
--- a/lib/MooseX/Types/LoadableClass.pm
+++ b/lib/MooseX/Types/LoadableClass.pm
@@ -36,7 +36,6 @@ coerce LoadableRole, from Str, via { $_ };
 __PACKAGE__->type_storage->{ClassName}
     = __PACKAGE__->type_storage->{LoadableClass};
 
-__PACKAGE__->meta->make_immutable;
 1;
 __END__
 


### PR DESCRIPTION
Prior to MooseX::Types 0.51, the type library packages would be Moose classes. They are only type libraries and exporters though, and aren't meant to be used as classes. In MooseX::Types 0.51, they are no longer classes, so ->meta can't be called on them.

Since the packages are never instantiated, calling ->make_immutable serves no purpose, including on older versions of MooseX::Types.